### PR TITLE
Add .ico to excluded audio, image, and video files

### DIFF
--- a/src/js/lint-all.js
+++ b/src/js/lint-all.js
@@ -169,6 +169,7 @@ fluid.defaults("fluid.lintAll.checkRunner", {
                 "excludes": [
                     "./package-lock.json",
                     "*.gif",
+                    "*.ico",
                     "*.jpg",
                     "*.jpeg",
                     "*.mp3",


### PR DESCRIPTION
While adding this linter to [codelearncreate/c2lc-project-website](https://github.com/codelearncreate/c2lc-project-website/), I noticed that `.ico` files (used for favicons) are not part of the default binary audio/image/video filetype excludes for `lintspaces.newlines` (#4). This PR adds them to the list.