### PR TITLE
GH-26: Disabled indentation checks for JS comments (resolves #26).

### DIFF
--- a/src/js/lint-all.js
+++ b/src/js/lint-all.js
@@ -160,7 +160,8 @@ fluid.defaults("fluid.lintAll.checkRunner", {
                 "excludes": ["./package-lock.json"],
                 "options": {
                     indentation: "spaces",
-                    spaces: 4
+                    spaces: 4,
+                    ignores: ["js-comments"]
                 }
             },
             "newlines": {

--- a/tests/fixtures/json5/spaced-comments.json5
+++ b/tests/fixtures/json5/spaced-comments.json5
@@ -1,0 +1,10 @@
+/*
+ * This is the 6th config
+ */
+{
+    "type": "config6",
+    "options": {
+        "gradeNames": ["fluid.component"],
+        "option6": "OPTION6"
+    }
+}


### PR DESCRIPTION
Ignore JS comments in `lintspaces.newlines` checks.  See #26 for context.