### PR TITLE
GH-38: Add `package-lock.json` to excludes for additional checks (resolves #38).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fluid-lint-all",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Run the Fluid community's standard linting checks.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fluid-lint-all",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Run the Fluid community's standard linting checks.",
     "main": "index.js",
     "bin": {

--- a/src/js/lint-all.js
+++ b/src/js/lint-all.js
@@ -240,7 +240,7 @@ fluid.defaults("fluid.lintAll.checkRunner", {
         },
         "jsonlint": {
             "includes": "{that}.options.userConfig.sources.json",
-            "excludes": []
+            "excludes": ["./package-lock.json"]
         },
         "lintspaces": {
             "jsonindentation": {
@@ -250,7 +250,7 @@ fluid.defaults("fluid.lintAll.checkRunner", {
                         args: [["{that}.options.userConfig.sources.json", "{that}.options.userConfig.sources.json5"]]
                     }
                 },
-                "excludes": []
+                "excludes": ["./package-lock.json"]
             },
             "newlines": {
                 "includes": ["./src/**/*", "./tests/**/*", "./*"],


### PR DESCRIPTION
See #39 for details.

@greatislander, I have cut `1.1.4-dev.20210604T105954Z.979a7d8.GH-38` with the changes proposed here.  Please give it a try, hopefully it'll work better for you.