### PR TITLE
GH-39: Fixed empty "checked" and "valid" file counts for stylelint check (resolves #39).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fluid-lint-all",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Run the Fluid community's standard linting checks.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fluid-lint-all",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Run the Fluid community's standard linting checks.",
     "main": "index.js",
     "bin": {

--- a/src/js/stylelint.js
+++ b/src/js/stylelint.js
@@ -39,6 +39,8 @@ fluid.lintAll.stylelint.runChecks = function (that, filesToScan) {
             stylelintPromise.then(function (results) {
                 if (results.errored) {
                     fluid.each(results.results, function (fileResults) {
+                        that.results.checked++;
+
                         if (fileResults.invalidOptionWarnings || fileResults.errored) {
                             var relativePath = path.relative(that.options.rootPath, fileResults.source);
                             that.results.errorsByPath[relativePath] = [];

--- a/src/js/stylelint.js
+++ b/src/js/stylelint.js
@@ -30,6 +30,8 @@ fluid.lintAll.stylelint.runChecks = function (that, filesToScan) {
     var wrappedPromise = fluid.promise();
 
     if (filesToScan.length) {
+        that.results.checked = filesToScan.length;
+
         var stylelintOptions = fluid.copy(that.options.config.options);
         stylelintOptions.files = filesToScan;
 
@@ -39,9 +41,7 @@ fluid.lintAll.stylelint.runChecks = function (that, filesToScan) {
             stylelintPromise.then(function (results) {
                 if (results.errored) {
                     fluid.each(results.results, function (fileResults) {
-                        that.results.checked++;
-
-                        if (fileResults.invalidOptionWarnings || fileResults.errored) {
+                        if (fileResults.invalidOptionWarnings.length || fileResults.errored) {
                             var relativePath = path.relative(that.options.rootPath, fileResults.source);
                             that.results.errorsByPath[relativePath] = [];
                             that.results.invalid++;

--- a/tests/js/lintAll-tests.js
+++ b/tests/js/lintAll-tests.js
@@ -14,16 +14,11 @@ fluid.test.lintAll.checkSingleTally = function (tally) {
         jqUnit.assertTrue("Each tally entry should not be negative.", singleTallyEntry >= 0);
     });
 
-    jqUnit.assertTrue("The tally entries should match.", tally.checked === (tally.valid + tally.invalid));
+    jqUnit.assertTrue("The tally entries should match each other.", tally.checked === (tally.valid + tally.invalid));
 };
 
 fluid.test.lintAll.checkSingleResult = function (testDef) {
     jqUnit.asyncTest(testDef.message, function () {
-        // There is always an overall integrity check for the promise mechanisms used.
-        // If the run should fail, there should be one more check confirming the promise was rejected.
-        // If the run succeeds, there should be 10 checks * 7 tests, and two additional summary checks.
-        jqUnit.expect(testDef.shouldFail ? 2 : 74);
-
         var allChecksPromise = fluid.lintAll.runAllChecks(testDef.argsOptions);
         jqUnit.assertTrue("`runAllChecks` should return a promise.", fluid.isPromise(allChecksPromise));
 
@@ -97,6 +92,23 @@ fluid.test.lintAll.runTests = function () {
             message: "If we run with no custom arguments, the checks should pass.",
             argsOptions: {},
             expected: { checked: 0, valid: 0, invalid: 0 }
+        },
+        // Checked specifically to guard against regressions on GH-39.
+        styleLintExcludes: {
+            message: "The stylelint totals should be correct when there are no errors.",
+            argsOptions: {
+                checks: ["stylelint"]
+            },
+            expected: { checked: 2, valid: 2, invalid: 0}
+        },
+        styleLintNoExcludes: {
+            message: "The stylelint totals should be correct when there are errors.",
+            argsOptions: {
+                configFile: ".fluidlintall-no-excludes.json",
+                checks: ["stylelint"]
+            },
+            expected: { checked: 4, valid: 2, invalid: 2},
+            shouldFail: true
         }
     };
 


### PR DESCRIPTION
See #39 for details.  The `stylelint`check was not reporting either valid or checked files correctly.

@greatislander, I have a fix for this in the dev release of `1.1.4-dev.20210604T111117Z.fa5f34f.GH-39 `.