### PR TITLE
GH-45: Ensure that runs fail if there are ESLint processing errors (resolves #45).

### DIFF
--- a/src/js/eslint.js
+++ b/src/js/eslint.js
@@ -85,7 +85,7 @@ fluid.lintAll.eslint.runSingleCheck = function (that, filesToScan) {
                 },
                 function (error) {
                     fluid.log(fluid.logLevel.WARN, "ERROR: ESLint check failed: " + error.message);
-                    wrappedPromise.resolve(that.results);
+                    wrappedPromise.reject(that.results);
                 }
             );
         }

--- a/src/js/eslint.js
+++ b/src/js/eslint.js
@@ -91,7 +91,7 @@ fluid.lintAll.eslint.runSingleCheck = function (that, filesToScan) {
         }
         catch (error) {
             fluid.log(fluid.logLevel.WARN, "ERROR: ESLint check threw an error: " + error.message);
-            wrappedPromise.resolve(that.results);
+            wrappedPromise.reject(that.results);
         }
     }
     else {


### PR DESCRIPTION
See #45 for details.